### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ console.log(floor(18, 5))
 
 # round up to the nearest integer
 # prints 5
-console.log(ceil(4.9, 5))
+console.log(ceil(4.9))
 
 # round up to the next highest multiple of 7
 # prints 21


### PR DESCRIPTION
`ceil(4.9, 5)` would round to the nearest `5`, not the nearest *integer*. I removed the `5` param so it would match the description of the docs.